### PR TITLE
Eap

### DIFF
--- a/html5-mobile/pom.xml
+++ b/html5-mobile/pom.xml
@@ -133,14 +133,14 @@
       <dependency>
          <groupId>org.jboss.arquillian.junit</groupId>
          <artifactId>arquillian-junit-container</artifactId>
-         <version>1.0.0.CR4</version>
+         <version>1.0.0.CR7</version>
          <scope>test</scope>
       </dependency>
             
       <dependency>
          <groupId>org.jboss.arquillian.protocol</groupId>
          <artifactId>arquillian-protocol-servlet</artifactId>
-         <version>1.0.0.CR4</version>
+         <version>1.0.0.CR7</version>
          <scope>test</scope>               
       </dependency>
 
@@ -176,7 +176,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.0.Beta1</version>
+            <version>7.1.0.Beta1b</version>
          </plugin>
       </plugins>
    </build>
@@ -215,7 +215,7 @@
             <dependency>
                <groupId>org.jboss.as</groupId>
                <artifactId>jboss-as-arquillian-container-managed</artifactId>
-               <version>${arquillian.jboss7.version}</version>
+               <version>7.1.0.Beta1b</version>
                <scope>test</scope>
             </dependency>
          </dependencies>
@@ -230,7 +230,7 @@
             <dependency>
                <groupId>org.jboss.as</groupId>
                <artifactId>jboss-as-arquillian-container-remote</artifactId>
-               <version>${arquillian.jboss7.version}</version>
+               <version>7.1.0.Beta1b</version>
                <scope>test</scope>
             </dependency>
          </dependencies>

--- a/kitchensink-ear/jboss-as-kitchensink-ear-ejb/pom.xml
+++ b/kitchensink-ear/jboss-as-kitchensink-ear-ejb/pom.xml
@@ -65,14 +65,14 @@
       <dependency>
          <groupId>org.jboss.arquillian.junit</groupId>
          <artifactId>arquillian-junit-container</artifactId>
-         <version>1.0.0.CR4</version>
+         <version>1.0.0.CR7</version>
          <scope>test</scope>
       </dependency>
       
       <dependency>
          <groupId>org.jboss.arquillian.protocol</groupId>
          <artifactId>arquillian-protocol-servlet</artifactId>
-         <version>1.0.0.CR4</version>
+         <version>1.0.0.CR7</version>
          <scope>test</scope>               
       </dependency>
 
@@ -125,7 +125,7 @@
             <dependency>
                <groupId>org.jboss.as</groupId>
                <artifactId>jboss-as-arquillian-container-managed</artifactId>
-               <version>${arquillian.jboss7.version}</version>
+               <version>7.1.0.Beta1b</version>
                <scope>test</scope>
             </dependency>
          </dependencies>
@@ -140,7 +140,7 @@
             <dependency>
                <groupId>org.jboss.as</groupId>
                <artifactId>jboss-as-arquillian-container-remote</artifactId>
-               <version>${arquillian.core.version}</version>
+               <version>7.1.0.Beta1b</version>
                <scope>test</scope>
             </dependency>
          </dependencies>

--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -110,7 +110,7 @@
             <plugin>
                <groupId>org.jboss.as.plugins</groupId>
                <artifactId>jboss-as-maven-plugin</artifactId>
-               <version>7.1.0.Beta1</version>
+               <version>7.1.0.Beta1b</version>
                <inherited>true</inherited>
                <configuration>
                   <skip>true</skip>

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -143,14 +143,14 @@
       <dependency>
          <groupId>org.jboss.arquillian.junit</groupId>
          <artifactId>arquillian-junit-container</artifactId>
-         <version>1.0.0.CR4</version>
+         <version>1.0.0.CR7</version>
          <scope>test</scope>
       </dependency>
       
       <dependency>
          <groupId>org.jboss.arquillian.protocol</groupId>
          <artifactId>arquillian-protocol-servlet</artifactId>
-         <version>1.0.0.CR4</version>
+         <version>1.0.0.CR7</version>
          <scope>test</scope>               
       </dependency>
 

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -129,14 +129,14 @@
       <dependency>
          <groupId>org.jboss.arquillian.junit</groupId>
          <artifactId>arquillian-junit-container</artifactId>
-         <version>1.0.0.CR6</version>
+         <version>1.0.0.CR7</version>
          <scope>test</scope>
       </dependency>
       
       <dependency>
          <groupId>org.jboss.arquillian.protocol</groupId>
          <artifactId>arquillian-protocol-servlet</artifactId>
-         <version>1.0.0.CR6</version>
+         <version>1.0.0.CR7</version>
          <scope>test</scope>               
       </dependency>
 
@@ -172,7 +172,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.0.Beta1</version>
+            <version>7.1.0.Beta1b</version>
          </plugin>
       </plugins>
    </build>
@@ -211,7 +211,7 @@
             <dependency>
                <groupId>org.jboss.as</groupId>
                <artifactId>jboss-as-arquillian-container-managed</artifactId>
-               <version>7.1.0.Beta1</version>
+               <version>7.1.0.Beta1b</version>
                <scope>test</scope>
             </dependency>
          </dependencies>
@@ -226,7 +226,7 @@
             <dependency>
                <groupId>org.jboss.as</groupId>
                <artifactId>jboss-as-arquillian-container-remote</artifactId>
-               <version>7.1.0.Beta1</version>
+               <version>7.1.0.Beta1b</version>
                <scope>test</scope>
             </dependency>
          </dependencies>


### PR DESCRIPTION
These changes fix most of the DR10 problems. All are related to wrong versions in pom.xml files.
The only issue outstanding is that kitchensink-ear won't deploy.
