### PR TITLE
Eap pom module fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ are noted with two asterisks ( ** ) following the quickstart name.
 * `helloworld-singleton` - Singleton Session Bean
 * `hibernate3` - Hibernate 3
 * `hibernate4` - Hibernate 4
+* `jax-rs-client` - External JAX-RS Client
 * `jts` - Using JTS to coordinate distributed transactions
 * `kitchensink` ** - CDI + JSF + JPA + EJB + JPA + JAX-RS + BV
 * `kitchensink-ear` - kitchensink as an EAR archive

--- a/dist/src/main/assembly/README.md
+++ b/dist/src/main/assembly/README.md
@@ -30,6 +30,7 @@ contains tutorials for:
 * `helloworld-singleton` - Singleton Session Bean
 * `hibernate3` - Hibernate 3
 * `hibernate4` - Hibernate 4
+* `jax-rs-client` - External JAX-RS Client
 * `jts` - Using JTS to coordinate distributed transactions
 * `kitchensink` - CDI + JSF + JPA + EJB + JPA + JAX-RS + BV
 * `kitchensink-ear` - kitchensink as an EAR archive

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     </licenses>
 
    <modules>
+      <module>bean-validation</module>
       <module>bmt</module>
       <module>cdi-injection</module>
       <module>cmt</module>
@@ -40,6 +41,9 @@
       <module>helloworld-osgi</module>
       <module>helloworld-rs</module>
       <module>helloworld-singleton</module>
+      <module>hibernate3</module>
+      <module>hibernate4</module>
+      <module>jax-rs-client</module>
       <module>jts</module>
       <module>kitchensink</module>
       <module>kitchensink-ear</module>
@@ -50,6 +54,9 @@
       <module>payment-cdi-event</module>
       <module>servlet-async</module>
       <module>servlet-filterlistener</module>
+      <module>wsat-simple</module>
+      <module>wsba-coordinator-completion-simple</module>
+      <module>wsba-participant-completion-simple</module>      
    </modules>
 
    <scm>


### PR DESCRIPTION
I modified the pom.xml file to add the missing quickstart modules. I also added the jax-rs-client to the README files in the root and in the dist/src/main directory.
