### PR TITLE
EAP 6 - remove repositories from the pom.xml files

### DIFF
--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -186,39 +186,6 @@
       </profile>
 
       <profile>
-         <!-- We add the JBoss repository as we need the JBoss AS connectors 
-            for Arquillian -->
-         <repositories>
-            <!-- The JBoss Community public repository is a composite repository 
-               of several major repositories -->
-            <!-- see http://community.jboss.org/wiki/MavenGettingStarted-Users -->
-            <repository>
-               <id>jboss-public-repository</id>
-               <name>JBoss Repository</name>
-               <url>http://repository.jboss.org/nexus/content/groups/public</url>
-               <!-- These optional flags are designed to speed up your builds 
-                  by reducing remote server calls -->
-               <releases>
-               </releases>
-               <snapshots>
-                  <enabled>false</enabled>
-               </snapshots>
-            </repository>
-         </repositories>
-
-         <pluginRepositories>
-            <pluginRepository>
-               <id>jboss-public-repository</id>
-               <name>JBoss Repository</name>
-               <url>http://repository.jboss.org/nexus/content/groups/public</url>
-               <releases>
-               </releases>
-               <snapshots>
-                  <enabled>false</enabled>
-               </snapshots>
-            </pluginRepository>
-         </pluginRepositories>
-
          <!-- An optional Arquillian testing profile that executes tests 
             in your JBoss AS instance -->
          <!-- This profile will start a new JBoss AS instance, and execute 
@@ -236,39 +203,6 @@
       </profile>
 
       <profile>
-         <!-- We add the JBoss repository as we need the JBoss AS connectors 
-            for Arquillian -->
-         <repositories>
-            <!-- The JBoss Community public repository is a composite repository 
-               of several major repositories -->
-            <!-- see http://community.jboss.org/wiki/MavenGettingStarted-Users -->
-            <repository>
-               <id>jboss-public-repository</id>
-               <name>JBoss Repository</name>
-               <url>http://repository.jboss.org/nexus/content/groups/public</url>
-               <!-- These optional flags are designed to speed up your builds 
-                  by reducing remote server calls -->
-               <releases>
-               </releases>
-               <snapshots>
-                  <enabled>false</enabled>
-               </snapshots>
-            </repository>
-         </repositories>
-
-         <pluginRepositories>
-            <pluginRepository>
-               <id>jboss-public-repository</id>
-               <name>JBoss Repository</name>
-               <url>http://repository.jboss.org/nexus/content/groups/public</url>
-               <releases>
-               </releases>
-               <snapshots>
-                  <enabled>false</enabled>
-               </snapshots>
-            </pluginRepository>
-         </pluginRepositories>
-
          <!-- An optional Arquillian testing profile that executes tests 
             in a remote JBoss AS instance -->
          <!-- Run with: mvn clean test -Parq-jbossas-remote -->

--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -19,25 +19,6 @@
       </license>
    </licenses>
 
-    <repositories>
-      <!-- Add the JBoss repository for org.jboss</groupId:jboss-ejb-client 
-           this will not be necessary if it has been uploaded to central -->
-      <repository>
-          <id>jboss-public-repository-group</id>
-          <name>JBoss Public Repository Group</name>
-          <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-          <layout>default</layout>
-          <releases>
-          <enabled>true</enabled>
-          <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-          <enabled>true</enabled>
-          <updatePolicy>never</updatePolicy>
-          </snapshots>
-      </repository>
-    </repositories>
-
    <properties>
       <!-- Explicitly declaring the source encoding eliminates the following
          message: -->

--- a/helloworld-jsf/pom.xml
+++ b/helloworld-jsf/pom.xml
@@ -26,27 +26,6 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
    </properties>
 
-   <repositories>
-      <!-- Define the maven repositories where the RichFaces artifacts can be found.
-      You should consider using a repository manager or declare repositories in your settings.xml.
-      See http://www.sonatype.com/people/2009/02/why-putting-repositories-in-your-poms-is-a-bad-idea/
-      -->
-      <repository>
-         <id>jboss-public-repository-group</id>
-         <name>JBoss Public Maven Repository Group</name>
-         <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
-         <layout>default</layout>
-         <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-         </releases>
-         <snapshots>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-         </snapshots>
-      </repository>
-    </repositories>
-
    <dependencyManagement>
       <dependencies>
          <!-- Define the version of JBoss' Java EE 6 APIs we want to import. 

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -216,39 +216,6 @@
       </profile>
 
       <profile>
-         <!-- We add the JBoss repository as we need the JBoss AS connectors 
-            for Arquillian -->
-         <repositories>
-            <!-- The JBoss Community public repository is a composite repository 
-               of several major repositories -->
-            <!-- see http://community.jboss.org/wiki/MavenGettingStarted-Users -->
-            <repository>
-               <id>jboss-public-repository</id>
-               <name>JBoss Repository</name>
-               <url>http://repository.jboss.org/nexus/content/groups/public</url>
-               <!-- These optional flags are designed to speed up your builds 
-                  by reducing remote server calls -->
-               <releases>
-               </releases>
-               <snapshots>
-                  <enabled>false</enabled>
-               </snapshots>
-            </repository>
-         </repositories>
-
-         <pluginRepositories>
-            <pluginRepository>
-               <id>jboss-public-repository</id>
-               <name>JBoss Repository</name>
-               <url>http://repository.jboss.org/nexus/content/groups/public</url>
-               <releases>
-               </releases>
-               <snapshots>
-                  <enabled>false</enabled>
-               </snapshots>
-            </pluginRepository>
-         </pluginRepositories>
-
          <!-- An optional Arquillian testing profile that executes tests 
             in your JBoss AS instance -->
          <!-- This profile will start a new JBoss AS instance, and execute 
@@ -266,39 +233,6 @@
       </profile>
 
       <profile>
-         <!-- We add the JBoss repository as we need the JBoss AS connectors 
-            for Arquillian -->
-         <repositories>
-            <!-- The JBoss Community public repository is a composite repository 
-               of several major repositories -->
-            <!-- see http://community.jboss.org/wiki/MavenGettingStarted-Users -->
-            <repository>
-               <id>jboss-public-repository</id>
-               <name>JBoss Repository</name>
-               <url>http://repository.jboss.org/nexus/content/groups/public</url>
-               <!-- These optional flags are designed to speed up your builds 
-                  by reducing remote server calls -->
-               <releases>
-               </releases>
-               <snapshots>
-                  <enabled>false</enabled>
-               </snapshots>
-            </repository>
-         </repositories>
-
-         <pluginRepositories>
-            <pluginRepository>
-               <id>jboss-public-repository</id>
-               <name>JBoss Repository</name>
-               <url>http://repository.jboss.org/nexus/content/groups/public</url>
-               <releases>
-               </releases>
-               <snapshots>
-                  <enabled>false</enabled>
-               </snapshots>
-            </pluginRepository>
-         </pluginRepositories>
-
          <!-- An optional Arquillian testing profile that executes tests 
             in a remote JBoss AS instance -->
          <!-- Run with: mvn clean test -Parq-jbossas-remote -->

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -218,39 +218,6 @@
       </profile>
 
       <profile>
-         <!-- We add the JBoss repository as we need the JBoss AS connectors 
-            for Arquillian -->
-         <repositories>
-            <!-- The JBoss Community public repository is a composite repository 
-               of several major repositories -->
-            <!-- see http://community.jboss.org/wiki/MavenGettingStarted-Users -->
-            <repository>
-               <id>jboss-public-repository</id>
-               <name>JBoss Repository</name>
-               <url>http://repository.jboss.org/nexus/content/groups/public</url>
-               <!-- These optional flags are designed to speed up your builds 
-                  by reducing remote server calls -->
-               <releases>
-               </releases>
-               <snapshots>
-                  <enabled>false</enabled>
-               </snapshots>
-            </repository>
-         </repositories>
-
-         <pluginRepositories>
-            <pluginRepository>
-               <id>jboss-public-repository</id>
-               <name>JBoss Repository</name>
-               <url>http://repository.jboss.org/nexus/content/groups/public</url>
-               <releases>
-               </releases>
-               <snapshots>
-                  <enabled>false</enabled>
-               </snapshots>
-            </pluginRepository>
-         </pluginRepositories>
-
          <!-- An optional Arquillian testing profile that executes tests 
             in your JBoss AS instance -->
          <!-- This profile will start a new JBoss AS instance, and execute 
@@ -267,39 +234,6 @@
       </profile>
 
       <profile>
-         <!-- We add the JBoss repository as we need the JBoss AS connectors 
-            for Arquillian -->
-         <repositories>
-            <!-- The JBoss Community public repository is a composite repository 
-               of several major repositories -->
-            <!-- see http://community.jboss.org/wiki/MavenGettingStarted-Users -->
-            <repository>
-               <id>jboss-public-repository</id>
-               <name>JBoss Repository</name>
-               <url>http://repository.jboss.org/nexus/content/groups/public</url>
-               <!-- These optional flags are designed to speed up your builds 
-                  by reducing remote server calls -->
-               <releases>
-               </releases>
-               <snapshots>
-                  <enabled>false</enabled>
-               </snapshots>
-            </repository>
-         </repositories>
-
-         <pluginRepositories>
-            <pluginRepository>
-               <id>jboss-public-repository</id>
-               <name>JBoss Repository</name>
-               <url>http://repository.jboss.org/nexus/content/groups/public</url>
-               <releases>
-               </releases>
-               <snapshots>
-                  <enabled>false</enabled>
-               </snapshots>
-            </pluginRepository>
-         </pluginRepositories>
-
          <!-- An optional Arquillian testing profile that executes tests 
             in a remote JBoss AS instance -->
          <!-- Run with: mvn clean test -Parq-jbossas-remote -->

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -27,39 +27,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <!-- We add the JBoss repository as we need the JBoss AS connectors
-  for Arquillian and also for the JBossTS and XTS libraries-->
-    <repositories>
-        <!-- The JBoss Community public repository is a composite repository
-    of several major repositories -->
-        <!-- see http://community.jboss.org/wiki/MavenGettingStarted-Users -->
-        <repository>
-            <id>jboss-public-repository</id>
-            <name>JBoss Repository</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
-            <!-- These optional flags are designed to speed up your builds
-       by reducing remote server calls -->
-            <releases>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>jboss-public-repository</id>
-            <name>JBoss Repository</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
-            <releases>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
-
     <dependencyManagement>
         <dependencies>
           <dependency>

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -27,39 +27,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <!-- We add the JBoss repository as we need the JBoss AS connectors
-  for Arquillian and also for the JBossTS and XTS libraries-->
-    <repositories>
-        <!-- The JBoss Community public repository is a composite repository
-    of several major repositories -->
-        <!-- see http://community.jboss.org/wiki/MavenGettingStarted-Users -->
-        <repository>
-            <id>jboss-public-repository</id>
-            <name>JBoss Repository</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
-            <!-- These optional flags are designed to speed up your builds
-       by reducing remote server calls -->
-            <releases>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>jboss-public-repository</id>
-            <name>JBoss Repository</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
-            <releases>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
-
     <dependencyManagement>
         <dependencies>
         <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want to import.  -->

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -27,39 +27,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <!-- We add the JBoss repository as we need the JBoss AS connectors
-  for Arquillian and also for the JBossTS and XTS libraries-->
-    <repositories>
-        <!-- The JBoss Community public repository is a composite repository
-    of several major repositories -->
-        <!-- see http://community.jboss.org/wiki/MavenGettingStarted-Users -->
-        <repository>
-            <id>jboss-public-repository</id>
-            <name>JBoss Repository</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
-            <!-- These optional flags are designed to speed up your builds
-       by reducing remote server calls -->
-            <releases>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>jboss-public-repository</id>
-            <name>JBoss Repository</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
-            <releases>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
-
     <dependencyManagement>
         <dependencies>
         <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want to import.  -->


### PR DESCRIPTION
This was done for the following quickstarts:  cmt, ejb-remote, helloworld-jsf, hibernate4, kitchensink-jsp, wsat-simple, wsba-coordinator-completion-simple, and wsba-participant-completion-simple
