### PR TITLE
JBPAPP-8406: Add exclusions to some quickstart pom.xml files

### DIFF
--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -71,15 +71,36 @@
         <dependency>
             <groupId>org.jboss.jbossts</groupId>
             <artifactId>jbossxts-api</artifactId>
+            <version>4.16.2.Final-redhat-1</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.logging</groupId>
                     <artifactId>jboss-logging-spi</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>emma</groupId>
+                    <artifactId>emma</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>emma</groupId>
+                    <artifactId>emma_ant</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tanukisoft</groupId>
+                    <artifactId>wrapper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.integration</groupId>
+                    <artifactId>jboss-corba-ots-spi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.jbossas</groupId>
+                    <artifactId>jboss-server-manager</artifactId>
+                </exclusion>
             </exclusions>
-        </dependency>
-
+        </dependency> 
+ 
         <!-- Import the CDI API, we use provided scope as the API is included
         in JBoss AS 7 -->
         <dependency>

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -70,11 +70,32 @@
         <dependency>
             <groupId>org.jboss.jbossts</groupId>
             <artifactId>jbossxts-api</artifactId>
+            <version>4.16.2.Final-redhat-1</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.logging</groupId>
                     <artifactId>jboss-logging-spi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>emma</groupId>
+                    <artifactId>emma</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>emma</groupId>
+                    <artifactId>emma_ant</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tanukisoft</groupId>
+                    <artifactId>wrapper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.integration</groupId>
+                    <artifactId>jboss-corba-ots-spi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.jbossas</groupId>
+                    <artifactId>jboss-server-manager</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -64,14 +64,36 @@
         <dependency>
             <groupId>org.jboss.jbossts</groupId>
             <artifactId>jbossxts-api</artifactId>
+            <version>4.16.2.Final-redhat-1</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.logging</groupId>
                     <artifactId>jboss-logging-spi</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>emma</groupId>
+                    <artifactId>emma</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>emma</groupId>
+                    <artifactId>emma_ant</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tanukisoft</groupId>
+                    <artifactId>wrapper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.integration</groupId>
+                    <artifactId>jboss-corba-ots-spi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.jbossas</groupId>
+                    <artifactId>jboss-server-manager</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
+
 
         <!-- Import the CDI API, we use provided scope as the API is included
         in JBoss AS 7 -->


### PR DESCRIPTION
Modified the jbossxts-api version and added exclusions to some quickstart pom.xml files since the jbossxts build was bringing in some bad dependencies that prevented these quickstarts from being able to be deployed. With these exclusions, the quickstarts can now be deployed.
