### PR TITLE
Eap6 bom fixes part2

### DIFF
--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -93,30 +93,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- JSR-303 (Bean Validation) Implementation -->
-            <!-- Provides portable constraints such as @Email -->
-            <!-- Hibernate Validator is shipped in JBoss AS 7 -->
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-validator</artifactId>
-                <version>4.1.0.Final</version>
-                <scope>provided</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <!-- Test dependencies -->
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.10</version>
-                <type>jar</type>
-                <scope>test</scope>
-            </dependency>
 
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Remove version from hibernate-validator and junit artifacts in kitchensink-ear quickstart and move the artifacts from dependencyManagement to a separate dependencies section.
