### PR TITLE
Update references to EAP BOMs 1.0.0.M12-redhat-1 -> 1.0.1.CR1-redhat-1

### DIFF
--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>1.0.0.M12-redhat-1</version>
+                <version>1.0.1.CR1-redhat-1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>1.0.0.M12-redhat-1</version>
+                <version>1.0.1.CR1-redhat-1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/ejb-in-war/pom.xml
+++ b/ejb-in-war/pom.xml
@@ -52,7 +52,7 @@
          <dependency>
             <groupId>org.jboss.bom</groupId>
             <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-            <version>1.0.0.M12-redhat-1</version>
+            <version>1.0.1.CR1-redhat-1</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>

--- a/helloworld-html5/pom.xml
+++ b/helloworld-html5/pom.xml
@@ -37,7 +37,7 @@
 
         <!-- Define the version of JBoss' Java EE 6 APIs we want to import. Any dependencies from org.jboss.spec will have their
              version defined by this BOM -->
-        <javaee6.bom.version>1.0.0.M12-redhat-1</javaee6.bom.version>
+        <javaee6.bom.version>1.0.1.CR1-redhat-1</javaee6.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -36,9 +36,9 @@
       <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want to import.  -->
       <!-- <jboss.bom.version>1.0.0.M11</jboss.bom.version> -->
       <!-- Alternatively, comment out the above line, and un-comment the line below to
-         use version 1.0.0.M12-redhat-1 which is a release certified
+         use version 1.0.1.CR1-redhat-1 which is a release certified
          to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 maven repository. -->
-      <jboss.bom.version>1.0.0.M12-redhat-1</jboss.bom.version>
+      <jboss.bom.version>1.0.1.CR1-redhat-1</jboss.bom.version>
    </properties>
 
    <dependencyManagement>

--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -42,10 +42,10 @@
             to import. -->
               <!-- <jboss.bom.version>1.0.0.M11</jboss.bom.version> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.0.M12-redhat-1 which is a release certified 
+            line below to use version 1.0.1.CR1-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <jboss.bom.version>1.0.0.M12-redhat-1</jboss.bom.version>
+        <jboss.bom.version>1.0.1.CR1-redhat-1</jboss.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/kitchensink-html5-mobile/pom.xml
+++ b/kitchensink-html5-mobile/pom.xml
@@ -36,7 +36,7 @@
         <javaee6.web.spec.version>3.0.0.Final-redhat-1</javaee6.web.spec.version>
         <!-- <version.org.hibernate.validator>4.2.0.Final-redhat-1</version.org.hibernate.validator> -->
         
-        <jboss.bom.version>1.0.0.M12-redhat-1</jboss.bom.version>
+        <jboss.bom.version>1.0.1.CR1-redhat-1</jboss.bom.version>
         <wro4j.version>1.4.4</wro4j.version>
         
         <!-- Versions not covered in jboss-javaee-web-6.0 BOM  -->

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -37,9 +37,9 @@
       <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want to import.  -->
       <!-- <javaee6.with.tools.version>1.0.0.M11</javaee6.with.tools.version> -->
       <!-- Alternatively, comment out the above line, and un-comment the line below to 
-        use version 1.0.0.M12-redhat-1 which is a release certified 
+        use version 1.0.1.CR1-redhat-1 which is a release certified 
       to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 maven repository. -->
-      <javaee6.with.tools.version>1.0.0.M12-redhat-1</javaee6.with.tools.version> 
+      <javaee6.with.tools.version>1.0.1.CR1-redhat-1</javaee6.with.tools.version> 
    </properties>
 
    <dependencyManagement>

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -39,10 +39,10 @@
             to import. -->
               <!-- <jboss.bom.version>1.0.0.M11</jboss.bom.version> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.0.M12-redhat-1 which is a release certified 
+            line below to use version 1.0.1.CR1-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <jboss.bom.version>1.0.0.M12-redhat-1</jboss.bom.version>
+        <jboss.bom.version>1.0.1.CR1-redhat-1</jboss.bom.version>
     </properties>
 
 

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -42,9 +42,9 @@
         <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want to import.  -->
         <!-- <javaee6.with.tools.version>1.0.0.M11</javaee6.with.tools.version> -->
         <!-- Alternatively, comment out the above line, and un-comment the line below to
-        use version 1.0.0.M12-redhat-1 which is a release certified
+        use version 1.0.1.CR1-redhat-1 which is a release certified
         to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 maven repository. -->
-        <javaee6.with.tools.version>1.0.0.M12-redhat-1</javaee6.with.tools.version>
+        <javaee6.with.tools.version>1.0.1.CR1-redhat-1</javaee6.with.tools.version>
     </properties>
 
     <dependencyManagement>

--- a/tasks-rs/pom.xml
+++ b/tasks-rs/pom.xml
@@ -32,9 +32,9 @@
         <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want to import.  -->
         <!-- <javaee6.with.tools.version>1.0.0.M11</javaee6.with.tools.version> -->
         <!-- Alternatively, comment out the above line, and un-comment the line below to
-        use version 1.0.0.M12-redhat-1 which is a release certified
+        use version 1.0.1.CR1-redhat-1 which is a release certified
         to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 maven repository. -->
-        <javaee6.with.tools.version>1.0.0.M12-redhat-1</javaee6.with.tools.version>
+        <javaee6.with.tools.version>1.0.1.CR1-redhat-1</javaee6.with.tools.version>
 
     </properties>
 

--- a/tasks/pom.xml
+++ b/tasks/pom.xml
@@ -44,10 +44,10 @@
             to import. -->
               <!-- <javaee6.with.tools.version>1.0.0.M11</javaee6.with.tools.version> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.0.M12-redhat-1 which is a release certified 
+            line below to use version 1.0.1.CR1-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <javaee6.with.tools.version>1.0.0.M12-redhat-1</javaee6.with.tools.version>
+        <javaee6.with.tools.version>1.0.1.CR1-redhat-1</javaee6.with.tools.version>
     </properties>
 
     <dependencyManagement>

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -52,7 +52,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-                <version>1.0.0.M12-redhat-1</version>
+                <version>1.0.1.CR1-redhat-1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -62,7 +62,7 @@
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-transactions</artifactId>
-                <version>1.0.0.M12-redhat-1</version>
+                <version>1.0.1.CR1-redhat-1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
           <groupId>org.jboss.bom</groupId>
           <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-          <version>1.0.0.M12-redhat-1</version>
+          <version>1.0.1.CR1-redhat-1</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>
@@ -68,7 +68,7 @@
         <dependency>
           <groupId>org.jboss.bom</groupId>
           <artifactId>jboss-javaee-6.0-with-transactions</artifactId>
-          <version>1.0.0.M12-redhat-1</version>
+          <version>1.0.1.CR1-redhat-1</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -52,7 +52,7 @@
          <dependency>
             <groupId>org.jboss.bom</groupId>
             <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-            <version>1.0.0.M12-redhat-1</version>
+            <version>1.0.1.CR1-redhat-1</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>
@@ -62,7 +62,7 @@
          <dependency>
             <groupId>org.jboss.bom</groupId>
             <artifactId>jboss-javaee-6.0-with-transactions</artifactId>
-            <version>1.0.0.M12-redhat-1</version>
+            <version>1.0.1.CR1-redhat-1</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>


### PR DESCRIPTION
Hi,

we need upgrade to this new version of EAP BOMs. EAP Quickstarts uses MEAD Maven repository which contains a latest version, and 1.0.1.CR1-redhat-1 is that latest one there.

Thanks.
