### PR TITLE
Eap issue 39

### DIFF
--- a/jax-rs-client/pom.xml
+++ b/jax-rs-client/pom.xml
@@ -74,11 +74,11 @@
                     <systemProperties>
                         <property>
                             <name>xmlUrl</name>
-                            <value>http://localhost:8080/jboss-as-helloworld-rs/xml</value>
+                            <value>http://localhost:8080/jboss-as-helloworld-rs/rest/xml</value>
                         </property>
                         <property>
                             <name>jsonUrl</name>
-                            <value>http://localhost:8080/jboss-as-helloworld-rs/json</value>
+                            <value>http://localhost:8080/jboss-as-helloworld-rs/rest/json</value>
                         </property>
                     </systemProperties>
                 </configuration>


### PR DESCRIPTION
Add `rest/` to jax-rs-client URLs in the README and in the pom.xml files to fix issue #39.
Same issue was fixed upstream with this commit: https://github.com/sgilda/quickstart/commit/2cba35e5a308372a30b3d51facd6b17f5b060f36
