### PR TITLE
EAP6.0.1 quickstart fix: Add DB_CLOSE_DELAY=-1 parameter to h2 connection-url(s) 

### DIFF
--- a/bmt/src/main/webapp/WEB-INF/bmt-quickstart-ds.xml
+++ b/bmt/src/main/webapp/WEB-INF/bmt-quickstart-ds.xml
@@ -20,7 +20,7 @@
    <datasource jndi-name="java:jboss/datasources/BMTQuickstartDS"
       pool-name="bmt-quickstart" enabled="true"
       use-java-context="true">
-      <connection-url>jdbc:h2:mem:bmt-quickstart;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+      <connection-url>jdbc:h2:mem:bmt-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
       <driver>h2</driver>
       <security>
          <user-name>sa</user-name>

--- a/greeter/src/main/webapp/WEB-INF/greeter-quickstart-ds.xml
+++ b/greeter/src/main/webapp/WEB-INF/greeter-quickstart-ds.xml
@@ -20,7 +20,7 @@
    <datasource jndi-name="java:jboss/datasources/GreeterQuickstartDS"
       pool-name="greeter-quickstart" enabled="true"
       use-java-context="true">
-      <connection-url>jdbc:h2:mem:greeter-quickstart;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+      <connection-url>jdbc:h2:mem:greeter-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
       <driver>h2</driver>
       <security>
          <user-name>sa</user-name>

--- a/hibernate3/src/main/webapp/WEB-INF/hibernate3-quickstart-ds.xml
+++ b/hibernate3/src/main/webapp/WEB-INF/hibernate3-quickstart-ds.xml
@@ -20,7 +20,7 @@
    <datasource jndi-name="java:jboss/datasources/Hibernate3QuickstartDS"
       pool-name="hibernate3-quickstart" enabled="true"
       use-java-context="true">
-      <connection-url>jdbc:h2:mem:hibernate3-quickstart;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+      <connection-url>jdbc:h2:mem:hibernate3-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
       <driver>h2</driver>
       <security>
          <user-name>sa</user-name>

--- a/hibernate4/src/main/webapp/WEB-INF/hibernate4-quickstart-ds.xml
+++ b/hibernate4/src/main/webapp/WEB-INF/hibernate4-quickstart-ds.xml
@@ -20,7 +20,7 @@
    <datasource jndi-name="java:jboss/datasources/Hibernate4QuickstartDS"
       pool-name="hibernate4-quickstart" enabled="true"
       use-java-context="true">
-      <connection-url>jdbc:h2:mem:hibernate4-quickstart;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+      <connection-url>jdbc:h2:mem:hibernate4-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
       <driver>h2</driver>
       <security>
          <user-name>sa</user-name>

--- a/jta-crash-rec/src/main/webapp/WEB-INF/jta-crash-rec-quickstart-ds.xml
+++ b/jta-crash-rec/src/main/webapp/WEB-INF/jta-crash-rec-quickstart-ds.xml
@@ -12,7 +12,7 @@
 <datasources>
     <xa-datasource jndi-name="java:jboss/datasources/JTACrashRecQuickstartDS" pool-name="JTACrashRecQuickstart" enabled="true" use-ccm="false">
         <xa-datasource-property name="URL">
-            jdbc:h2:file:~/jta-crash-rec-quickstart;DB_CLOSE_ON_EXIT=FALSE
+            jdbc:h2:file:~/jta-crash-rec-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1
         </xa-datasource-property>
         <driver>h2</driver>
         <xa-pool>

--- a/kitchensink-ear/jboss-as-kitchensink-ear-ear/src/main/application/META-INF/kitchensink-ear-quickstart-ds.xml
+++ b/kitchensink-ear/jboss-as-kitchensink-ear-ear/src/main/application/META-INF/kitchensink-ear-quickstart-ds.xml
@@ -20,7 +20,7 @@
    <datasource jndi-name="java:jboss/datasources/KitchensinkEarQuickstartDS"
       pool-name="kitchensink-quickstart" enabled="true"
       use-java-context="true">
-      <connection-url>jdbc:h2:mem:kitchensink-ear-quickstart;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+      <connection-url>jdbc:h2:mem:kitchensink-ear-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
       <driver>h2</driver>
       <security>
          <user-name>sa</user-name>

--- a/kitchensink-jsp/src/main/webapp/WEB-INF/kitchensink-quickstart-ds.xml
+++ b/kitchensink-jsp/src/main/webapp/WEB-INF/kitchensink-quickstart-ds.xml
@@ -20,7 +20,7 @@
    <datasource jndi-name="java:jboss/datasources/KitchensinkJSPQuickstartDS"
       pool-name="kitchensink-jsp-quickstart" enabled="true"
       use-java-context="true">
-      <connection-url>jdbc:h2:mem:kitchensink-jsp-quickstart;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+      <connection-url>jdbc:h2:mem:kitchensink-jsp-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
       <driver>h2</driver>
       <security>
          <user-name>sa</user-name>

--- a/kitchensink/src/main/webapp/WEB-INF/kitchensink-quickstart-ds.xml
+++ b/kitchensink/src/main/webapp/WEB-INF/kitchensink-quickstart-ds.xml
@@ -20,7 +20,7 @@
    <datasource jndi-name="java:jboss/datasources/KitchensinkQuickstartDS"
       pool-name="kitchensink-quickstart" enabled="true"
       use-java-context="true">
-      <connection-url>jdbc:h2:mem:kitchensink-quickstart;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+      <connection-url>jdbc:h2:mem:kitchensink-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
       <driver>h2</driver>
       <security>
          <user-name>sa</user-name>

--- a/tasks-jsf/src/main/webapp/WEB-INF/tasks-jsf-ds.xml
+++ b/tasks-jsf/src/main/webapp/WEB-INF/tasks-jsf-ds.xml
@@ -20,7 +20,7 @@
    <datasource jndi-name="java:jboss/datasources/TasksJsfQuickstartDS"
       pool-name="tasks-jsf-quickstart" enabled="true"
       use-java-context="true">
-      <connection-url>jdbc:h2:mem:tasks-jsf-quickstart;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+      <connection-url>jdbc:h2:mem:tasks-jsf-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
       <driver>h2</driver>
       <security>
          <user-name>sa</user-name>

--- a/tasks-rs/src/main/webapp/WEB-INF/tasks-rs-ds.xml
+++ b/tasks-rs/src/main/webapp/WEB-INF/tasks-rs-ds.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
+<!-- JBoss, Home of Professional Open Source Copyright 2012, Red Hat, Inc. 
+    and/or its affiliates, and individual contributors by the @authors tag. See 
+    the copyright.txt in the distribution for a full listing of individual contributors. 
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+    use this file except in compliance with the License. You may obtain a copy 
+    of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+    by applicable law or agreed to in writing, software distributed under the 
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+    OF ANY KIND, either express or implied. See the License for the specific 
+    language governing permissions and limitations under the License. -->
+<!-- This is an unmanaged datasource. It should be used for proofs of concept 
+    or testing only. It uses H2, an in memory database that ships with JBoss 
+    AS. -->
 <datasources xmlns="http://www.jboss.org/ironjacamar/schema"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.jboss.org/ironjacamar/schema http://docs.jboss.org/ironjacamar/schema/datasources_1_0.xsd">
@@ -8,7 +20,7 @@
    <datasource jndi-name="java:jboss/datasources/TasksRsQuickstartDS"
       pool-name="tasks-rs-xml-quickstart" enabled="true"
       use-java-context="true">
-      <connection-url>jdbc:h2:mem:tasks-rs-xml-quickstart;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+      <connection-url>jdbc:h2:mem:tasks-rs-xml-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
       <driver>h2</driver>
       <security>
          <user-name>sa</user-name>

--- a/wicket-ear/ear/src/main/application/META-INF/wicket-ear-quickstart-ds.xml
+++ b/wicket-ear/ear/src/main/application/META-INF/wicket-ear-quickstart-ds.xml
@@ -20,7 +20,7 @@
     <datasource jndi-name="java:jboss/datasources/WicketEarQuickstartDS"
         pool-name="wicket-ear-quickstart" enabled="true"
         use-java-context="true">
-        <connection-url>jdbc:h2:mem:wicket-ear-quickstart;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+        <connection-url>jdbc:h2:mem:wicket-ear-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
         <driver>h2</driver>
         <security>
             <user-name>sa</user-name>

--- a/wicket-war/src/main/webapp/WEB-INF/wicket-quickstart-ds.xml
+++ b/wicket-war/src/main/webapp/WEB-INF/wicket-quickstart-ds.xml
@@ -20,7 +20,7 @@
     <datasource jndi-name="java:jboss/datasources/WicketQuickstartDS"
         pool-name="wicket-quickstart" enabled="true"
         use-java-context="true">
-        <connection-url>jdbc:h2:mem:wicket-quickstart;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+        <connection-url>jdbc:h2:mem:wicket-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
         <driver>h2</driver>
         <security>
             <user-name>sa</user-name>


### PR DESCRIPTION
To prevent loss of content when connection is closed
