### PR TITLE
Upgrade jboss-as-maven-plugin 7.1.1.Final -> 7.3.Final

### DIFF
--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -156,7 +156,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>7.1.1.Final</version>
+                    <version>7.3.Final</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/bmt/pom.xml
+++ b/bmt/pom.xml
@@ -125,7 +125,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates
             annotation processors -->

--- a/cdi-injection/pom.xml
+++ b/cdi-injection/pom.xml
@@ -102,7 +102,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -131,7 +131,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
         </plugins>
     </build>

--- a/ejb-in-ear/ear/pom.xml
+++ b/ejb-in-ear/ear/pom.xml
@@ -86,7 +86,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
                 <configuration>
                     <filename>jboss-as-ejb-in-ear.ear</filename>
                     <skip>false</skip>

--- a/ejb-in-ear/pom.xml
+++ b/ejb-in-ear/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/ejb-in-war/pom.xml
+++ b/ejb-in-war/pom.xml
@@ -126,7 +126,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -192,7 +192,7 @@
             <plugin>
                <groupId>org.jboss.as.plugins</groupId>
                <artifactId>jboss-as-maven-plugin</artifactId>
-               <version>7.1.1.Final</version>
+               <version>7.3.Final</version>
                <inherited>true</inherited>
                <configuration>
                   <skip>true</skip>

--- a/ejb-remote/pom.xml
+++ b/ejb-remote/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                <groupId>org.jboss.as.plugins</groupId>
                <artifactId>jboss-as-maven-plugin</artifactId>
-               <version>7.1.1.Final</version>
+               <version>7.3.Final</version>
                <inherited>true</inherited>
                <configuration>
                   <skip>true</skip>

--- a/ejb-remote/server-side/pom.xml
+++ b/ejb-remote/server-side/pom.xml
@@ -84,7 +84,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
             <configuration>
                 <filename>${project.build.finalName}.jar</filename>
             </configuration>

--- a/ejb-security/pom.xml
+++ b/ejb-security/pom.xml
@@ -97,7 +97,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/greeter/pom.xml
+++ b/greeter/pom.xml
@@ -128,7 +128,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/helloworld-html5/pom.xml
+++ b/helloworld-html5/pom.xml
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates
           annotation processors -->

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -103,7 +103,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
             <configuration>
                <username>admin</username>
                <password>admin</password>

--- a/helloworld-mdb/pom.xml
+++ b/helloworld-mdb/pom.xml
@@ -94,7 +94,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->

--- a/helloworld-osgi/pom.xml
+++ b/helloworld-osgi/pom.xml
@@ -79,7 +79,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
             <configuration>
                <filename>${project.build.finalName}.jar</filename>
             </configuration>

--- a/helloworld-rs/pom.xml
+++ b/helloworld-rs/pom.xml
@@ -103,7 +103,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/helloworld-singleton/pom.xml
+++ b/helloworld-singleton/pom.xml
@@ -89,7 +89,7 @@
 			<plugin>
 				<groupId>org.jboss.as.plugins</groupId>
 				<artifactId>jboss-as-maven-plugin</artifactId>
-				<version>7.1.1.Final</version>
+				<version>7.3.Final</version>
 			</plugin>
 			<!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation 
 				processors -->

--- a/helloworld/pom.xml
+++ b/helloworld/pom.xml
@@ -102,7 +102,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/hibernate3/pom.xml
+++ b/hibernate3/pom.xml
@@ -286,7 +286,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -198,7 +198,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
       </plugins>
    </build>

--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -141,7 +141,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->

--- a/jts/application-component-2/pom.xml
+++ b/jts/application-component-2/pom.xml
@@ -95,7 +95,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
                 <configuration>
                     <port>10099</port>
                 </configuration>

--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -69,7 +69,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>7.1.1.Final</version>
+                    <version>7.3.Final</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -118,7 +118,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>7.1.1.Final</version>
+                    <version>7.3.Final</version>
                     <inherited>true</inherited>
                     <configuration>
                         <skip>true</skip>

--- a/kitchensink-html5-mobile/pom.xml
+++ b/kitchensink-html5-mobile/pom.xml
@@ -201,7 +201,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
             
             <plugin>

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -208,7 +208,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
       </plugins>
    </build>

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -213,7 +213,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
         </plugins>
     </build>

--- a/log4j/pom.xml
+++ b/log4j/pom.xml
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>org.jboss.as.plugins</groupId>
 				<artifactId>jboss-as-maven-plugin</artifactId>
-				<version>7.1.1.Final</version>
+				<version>7.3.Final</version>
 			</plugin>
 			<!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation 
 				processors -->

--- a/logging-tools/pom.xml
+++ b/logging-tools/pom.xml
@@ -97,7 +97,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
 
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -102,7 +102,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/numberguess/pom.xml
+++ b/numberguess/pom.xml
@@ -104,7 +104,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -114,7 +114,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
                 <inherited>true</inherited>
                 <configuration>
                     <skip>true</skip>

--- a/servlet-async/pom.xml
+++ b/servlet-async/pom.xml
@@ -110,7 +110,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/servlet-filterlistener/pom.xml
+++ b/servlet-filterlistener/pom.xml
@@ -103,7 +103,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/servlet-security/pom.xml
+++ b/servlet-security/pom.xml
@@ -93,7 +93,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/shopping-cart/pom.xml
+++ b/shopping-cart/pom.xml
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
                 <inherited>true</inherited>
                 <configuration>
                     <skip>true</skip>

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -157,7 +157,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
         </plugins>
     </build>

--- a/tasks-rs/pom.xml
+++ b/tasks-rs/pom.xml
@@ -157,7 +157,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
         </plugins>
     </build>

--- a/tasks/pom.xml
+++ b/tasks/pom.xml
@@ -154,7 +154,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/temperature-converter/pom.xml
+++ b/temperature-converter/pom.xml
@@ -112,7 +112,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -128,7 +128,7 @@
          <plugin>
             <groupId>org.jboss.as.plugins</groupId>
             <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>7.1.1.Final</version>
+            <version>7.3.Final</version>
          </plugin>
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
             annotation processors -->

--- a/wicket-ear/pom.xml
+++ b/wicket-ear/pom.xml
@@ -127,7 +127,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>7.1.1.Final</version>
+                    <version>7.3.Final</version>
                     <inherited>true</inherited>
                     <configuration>
                         <skip>true</skip>

--- a/wicket-war/pom.xml
+++ b/wicket-war/pom.xml
@@ -195,7 +195,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
                 <configuration>
                     <fileNames>
                         <fileName>target/${build.finalName}.war</fileName>

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -150,7 +150,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates
           annotation processors -->

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -140,7 +140,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -134,7 +134,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
                 <configuration>
                   <skip>true</skip>
                 </configuration>

--- a/xml-dom4j/pom.xml
+++ b/xml-dom4j/pom.xml
@@ -134,7 +134,7 @@
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>7.1.1.Final</version>
+                <version>7.3.Final</version>
             </plugin>
             <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
                 annotation processors -->

--- a/xml-jaxp/pom.xml
+++ b/xml-jaxp/pom.xml
@@ -123,7 +123,7 @@
 			<plugin>
 				<groupId>org.jboss.as.plugins</groupId>
 				<artifactId>jboss-as-maven-plugin</artifactId>
-				<version>7.1.1.Final</version>
+				<version>7.3.Final</version>
 			</plugin>
 			<!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation 
 				processors -->


### PR DESCRIPTION
Hi,

we need upgrade jboss-as-maven-plugin to 7.3.Final for proper usage in EAP 6.0.1 (based on AS 7.1.3.Final).

Thanks.
