### PR TITLE
Pom fix for EAP 6.0.1 ER4

### DIFF
--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -58,7 +58,7 @@
          <dependency>
              <groupId>org.jboss.as</groupId>
              <artifactId>jboss-as-ejb-client-bom</artifactId>
-             <version>7.1.3.Final-redhat-3</version>
+             <version>7.1.3.Final-redhat-4</version>
              <type>pom</type>
              <scope>import</scope>
          </dependency>

--- a/ejb-security/pom.xml
+++ b/ejb-security/pom.xml
@@ -56,7 +56,7 @@
          <dependency>
              <groupId>org.jboss.as</groupId>
              <artifactId>jboss-as-ejb-client-bom</artifactId>
-             <version>7.1.3.Final-redhat-3</version>
+             <version>7.1.3.Final-redhat-4</version>
              <type>pom</type>
              <scope>import</scope>
          </dependency>

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -41,7 +41,7 @@
       <dependency>
          <groupId>org.jboss.as</groupId>
          <artifactId>jboss-as-jms-client-bom</artifactId>
-         <version>7.1.3.Final-redhat-3</version>
+         <version>7.1.3.Final-redhat-4</version>
          <type>pom</type>
       </dependency>
    </dependencies>

--- a/kitchensink-html5-mobile/pom.xml
+++ b/kitchensink-html5-mobile/pom.xml
@@ -402,7 +402,7 @@
                                         <artifactItem>
                                             <groupId>org.jboss.as</groupId>
                                             <artifactId>jboss-as-dist</artifactId>
-                                            <version>7.1.3.Final-redhat-3</version>
+                                            <version>7.1.3.Final-redhat-4</version>
                                             <outputDirectory>${project.build.directory}</outputDirectory>
                                             <type>zip</type>
                                             <overWrite>false</overWrite>

--- a/shopping-cart/pom.xml
+++ b/shopping-cart/pom.xml
@@ -58,10 +58,10 @@
             should match the JBoss AS version in use -->
         <!-- <jboss.ejb.client.version>7.1.2.Final</jboss.ejb.client.version> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 7.1.3.Final-redhat-3 which is a release certified 
+            line below to use version 7.1.3.Final-redhat-4 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <jboss.ejb.client.version>7.1.3.Final-redhat-3</jboss.ejb.client.version>
+        <jboss.ejb.client.version>7.1.3.Final-redhat-4</jboss.ejb.client.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Hi,

please merge this fixed poms syncing jboss-as artifacts version with the EAP 6.0.1 ER4. It's necessary to have this fix to include quickstarts in EAP 6.0.1 ER4.

Thanks.
