### PR TITLE
[915368] Fix issue with using jboss-logging-processor 3.1.0

### DIFF
--- a/logging-tools/pom.xml
+++ b/logging-tools/pom.xml
@@ -47,7 +47,7 @@
         <version.org.jboss.bom>1.0.4.Final-redhat-2</version.org.jboss.bom>
 
         <!-- other plugin versions -->
-        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+        <version.compiler.plugin>3.0</version.compiler.plugin>
         <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
                 <module>kitchensink-ml</module>
                 <module>kitchensink-ml-ear</module>
                 <module>log4j</module>
-                <!--<module>logging-tools</module>-->
+                <module>logging-tools</module>
                 <module>mail</module>
                 <module>numberguess</module>
                 <module>payment-cdi-event</module>


### PR DESCRIPTION
- Update version of maven compiler plugin used with logging-tools example
- Enable logging-tools module in root pom
