### PR TITLE
Update quickstarts for EAP 6.1.1 ER4

### DIFF
--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -47,10 +47,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator>
         <version.org.hibernate-jpamodelgen>1.1.1.Final</version.org.hibernate-jpamodelgen>

--- a/cdi-portable-extension/pom.xml
+++ b/cdi-portable-extension/pom.xml
@@ -43,10 +43,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/cdi-veto/pom.xml
+++ b/cdi-veto/pom.xml
@@ -43,10 +43,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/cluster-ha-singleton/pom.xml
+++ b/cluster-ha-singleton/pom.xml
@@ -44,7 +44,7 @@
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final</version.org.jboss.spec.jboss.javaee.6.0> -->
         <!-- Alternatively, comment out the above line, and un-comment the 

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -42,10 +42,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/ejb-asynchronous/pom.xml
+++ b/ejb-asynchronous/pom.xml
@@ -44,7 +44,7 @@
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final</version.org.jboss.spec.jboss.javaee.6.0> -->
         <!-- Alternatively, comment out the above line, and un-comment the 

--- a/ejb-in-ear/pom.xml
+++ b/ejb-in-ear/pom.xml
@@ -49,7 +49,7 @@
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final</version.org.jboss.spec.jboss.javaee.6.0> -->
         <!-- Alternatively, comment out the above line, and un-comment the 

--- a/ejb-in-war/pom.xml
+++ b/ejb-in-war/pom.xml
@@ -41,10 +41,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -45,7 +45,7 @@
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final</version.org.jboss.spec.jboss.javaee.6.0> -->
         <!-- Alternatively, comment out the above line, and un-comment the 

--- a/ejb-security-interceptors/pom.xml
+++ b/ejb-security-interceptors/pom.xml
@@ -45,7 +45,7 @@
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final</version.org.jboss.spec.jboss.javaee.6.0> -->
         <!-- Alternatively, comment out the above line, and un-comment the 

--- a/ejb-security/pom.xml
+++ b/ejb-security/pom.xml
@@ -44,7 +44,7 @@
             line below to use version 7.1.1.Final which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final</version.org.jboss.spec.jboss.javaee.6.0> -->
         <!-- Alternatively, comment out the above line, and un-comment the 

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -44,7 +44,7 @@
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/helloworld-singleton/pom.xml
+++ b/helloworld-singleton/pom.xml
@@ -41,10 +41,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final</version.org.jboss.spec.jboss.javaee.6.0> -->
         <!-- Alternatively, comment out the above line, and un-comment the 

--- a/helloworld-ws/pom.xml
+++ b/helloworld-ws/pom.xml
@@ -43,10 +43,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.war.plugin>2.1.1</version.war.plugin>

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -41,17 +41,17 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- <version.org.jboss.as>7.2.0.Alpha1-SNAPSHOT</version.org.jboss.as> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/jax-rs-client/pom.xml
+++ b/jax-rs-client/pom.xml
@@ -42,10 +42,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- Other dependency versions -->
         <version.org.apache.httpcomponents>4.2.1-redhat-1</version.org.apache.httpcomponents>

--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -44,7 +44,7 @@
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final</version.org.jboss.spec.jboss.javaee.6.0> -->
         <!-- Alternatively, comment out the above line, and un-comment the 

--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -46,17 +46,17 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- <version.org.jboss.as>7.2.0.Alpha1-SNAPSHOT</version.org.jboss.as> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -43,10 +43,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <version.org.hibernate-jpamodelgen>1.1.1.Final</version.org.hibernate-jpamodelgen>
 

--- a/kitchensink-ml-ear/pom.xml
+++ b/kitchensink-ml-ear/pom.xml
@@ -46,17 +46,17 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- <version.org.jboss.as>7.2.0.Alpha1-SNAPSHOT</version.org.jboss.as> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/kitchensink-ml/pom.xml
+++ b/kitchensink-ml/pom.xml
@@ -43,10 +43,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -41,10 +41,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/logging-tools/pom.xml
+++ b/logging-tools/pom.xml
@@ -41,10 +41,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>3.0</version.compiler.plugin>

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -43,10 +43,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final</version.org.jboss.spec.jboss.javaee.6.0> -->
         <!-- Alternatively, comment out the above line, and un-comment the 

--- a/pom.xml
+++ b/pom.xml
@@ -41,20 +41,20 @@
 
         <!-- <version.org.jboss.as>7.2.0.Alpha1-SNAPSHOT</version.org.jboss.as> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 7.2.1.Final-redhat-4 which is a release certified 
+            line below to use version 7.2.1.Final-redhat-5 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <version.org.jboss.as.plugins.maven.plugin>7.3.Final</version.org.jboss.as.plugins.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final</version.org.jboss.spec.jboss.javaee.6.0> -->
         <!-- Alternatively, comment out the above line, and un-comment the 

--- a/shopping-cart/pom.xml
+++ b/shopping-cart/pom.xml
@@ -56,7 +56,7 @@
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
 
         <!-- <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final</version.org.jboss.spec.jboss.javaee.6.0> -->
         <!-- Alternatively, comment out the above line, and un-comment the 

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -47,10 +47,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/tasks-rs/pom.xml
+++ b/tasks-rs/pom.xml
@@ -34,10 +34,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/tasks/pom.xml
+++ b/tasks/pom.xml
@@ -48,17 +48,17 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- <version.org.jboss.as>7.2.0.Alpha1-SNAPSHOT</version.org.jboss.as> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
             line below to use version 7.1.1.Final-redhat-1 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.as>7.2.1.Final-redhat-4</version.org.jboss.as>
+        <version.org.jboss.as>7.2.1.Final-redhat-5</version.org.jboss.as>
         
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -42,10 +42,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -43,10 +43,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -42,10 +42,10 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <!-- <version.org.jboss.bom>1.0.4.Final</version.org.jboss.bom> -->
         <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.4.Final-redhat-5 which is a release certified 
+            line below to use version 1.0.4.Final-redhat-6 which is a release certified 
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
-        <version.org.jboss.bom>1.0.4.Final-redhat-5</version.org.jboss.bom>
+        <version.org.jboss.bom>1.0.4.Final-redhat-6</version.org.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>


### PR DESCRIPTION
Updating JBoss BOM version to 1.0.4.Final-redhat-6 and JBoss AS version to 7.2.1.Final-redhat-5.
